### PR TITLE
New gadget for bitwise operations

### DIFF
--- a/src/fields/serialization.rs
+++ b/src/fields/serialization.rs
@@ -15,6 +15,7 @@ pub fn deserialize_field_element(bytes_field_element: Vec<u8>) -> Result<Constra
         .map_err(|e| anyhow!("Error deserializing field element: {e:?}"))
 }
 
+#[allow(clippy::print_stdout)]
 #[cfg(test)]
 mod tests {
     use super::serialize_field_element;

--- a/src/gadgets/helpers.rs
+++ b/src/gadgets/helpers.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use ark_ff::Field;
+use ark_r1cs_std::prelude::Boolean;
+use ark_relations::r1cs::SynthesisError;
+
+pub fn zip_bits_and_apply<F: Field, T>(
+    first_bits_to_iterate: Vec<Boolean<F>>,
+    second_bits_to_iterate: Vec<Boolean<F>>,
+    function_to_apply: T,
+) -> Result<Vec<Boolean<F>>>
+where
+    T: Fn(Boolean<F>, Boolean<F>) -> Result<Boolean<F>, SynthesisError>,
+{
+    let mut result = Vec::new();
+    for (left_operand_bit, right_operand_bit) in first_bits_to_iterate
+        .iter()
+        .zip(second_bits_to_iterate.iter())
+    {
+        let operation_result =
+            function_to_apply(left_operand_bit.clone(), right_operand_bit.clone())?;
+        result.push(operation_result);
+    }
+    Ok(result)
+}

--- a/src/gadgets/mod.rs
+++ b/src/gadgets/mod.rs
@@ -10,6 +10,8 @@ mod boolean;
 
 mod field;
 
+mod helpers;
+
 mod poseidon;
 pub use poseidon::poseidon2_hash;
 

--- a/src/gadgets/traits.rs
+++ b/src/gadgets/traits.rs
@@ -3,8 +3,6 @@ use ark_ff::Field;
 use ark_r1cs_std::{uint8::UInt8, ToBitsGadget, ToBytesGadget};
 use ark_relations::r1cs::ConstraintSystemRef;
 
-use super::UInt8Gadget;
-
 pub trait ToFieldElements<F: Field> {
     fn to_field_elements(&self) -> Result<Vec<F>>;
 }
@@ -42,7 +40,7 @@ pub trait FromBytesGadget<F: Field> {
         Self: Sized;
 }
 
-pub trait BitRotationGadget<F: Field> {
+pub trait ByteRotationGadget<F: Field> {
     fn rotate_left(
         &self,
         positions: usize,
@@ -60,7 +58,27 @@ pub trait BitRotationGadget<F: Field> {
         Self: std::marker::Sized;
 }
 
-pub trait BitShiftGadget<F: Field> {
+pub trait BitwiseOperationGadget<F: Field> {
+    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>;
+
+    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>;
+
+    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>;
+
+    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>;
+
+    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>;
+
     fn shift_left(
         &self,
         positions: usize,
@@ -76,9 +94,7 @@ pub trait BitShiftGadget<F: Field> {
     ) -> Result<Self>
     where
         Self: std::marker::Sized;
-}
 
-pub trait ByteRotationGadget<F: Field> {
     fn rotate_left(
         &self,
         positions: usize,

--- a/src/gadgets/uint128.rs
+++ b/src/gadgets/uint128.rs
@@ -1,6 +1,5 @@
-use super::traits::{
-    BitRotationGadget, BitShiftGadget, FromBytesGadget, IsWitness, ToFieldElements,
-};
+use super::helpers::zip_bits_and_apply;
+use super::traits::{BitwiseOperationGadget, FromBytesGadget, IsWitness, ToFieldElements};
 use anyhow::Result;
 use ark_ff::Field;
 use ark_r1cs_std::{
@@ -59,7 +58,72 @@ impl<F: Field> FromBytesGadget<F> for UInt128<F> {
     }
 }
 
-impl<F: Field> BitRotationGadget<F> for UInt128<F> {
+impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
+    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| first_bit.and(&second_bit),
+        )?;
+        let new_value = UInt128::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
+        )?;
+        let new_value = UInt128::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
+        )?;
+        let new_value = UInt128::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| first_bit.or(&second_bit),
+        )?;
+        let new_value = UInt128::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| first_bit.xor(&second_bit),
+        )?;
+        let new_value = UInt128::from_bits_le(&result);
+        Ok(new_value)
+    }
+
     fn rotate_left(
         &self,
         positions: usize,
@@ -71,10 +135,13 @@ impl<F: Field> BitRotationGadget<F> for UInt128<F> {
         rotated_bits.rotate_left(positions);
 
         for i in 0..128 {
-            let a = &primitive_bits[(i + positions) % 128];
-            let b = &rotated_bits[i];
-            let c = lc!() + a.lc() - b.lc();
-            constraint_system.enforce_constraint(lc!(), lc!(), c)?
+            if let (Some(a), Some(b)) = (
+                &primitive_bits.get((i + positions) % 128),
+                &rotated_bits.get(i),
+            ) {
+                let c = lc!() + a.lc() - b.lc();
+                constraint_system.enforce_constraint(lc!(), lc!(), c)?
+            }
         }
 
         rotated_bits.reverse();
@@ -92,9 +159,7 @@ impl<F: Field> BitRotationGadget<F> for UInt128<F> {
         // tries to rotate more then 128 positions.
         self.rotate_left(128 - (positions % 128), constraint_system)
     }
-}
 
-impl<F: Field> BitShiftGadget<F> for UInt128<F> {
     fn shift_left(
         &self,
         positions: usize,
@@ -199,10 +264,7 @@ impl<F: Field> BitShiftGadget<F> for UInt128<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::gadgets::{
-        traits::{BitRotationGadget, BitShiftGadget},
-        ConstraintF, UInt128Gadget,
-    };
+    use crate::gadgets::{traits::BitwiseOperationGadget, ConstraintF, UInt128Gadget};
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 
@@ -274,7 +336,7 @@ mod tests {
     fn test_one_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = byte.value().unwrap() << positions_to_shift;
 
         let result = byte
@@ -289,7 +351,7 @@ mod tests {
     fn test_more_than_one_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 2;
+        let positions_to_shift = 2_i32;
         let expected_byte = byte.value().unwrap() << positions_to_shift;
 
         let result = byte
@@ -304,7 +366,7 @@ mod tests {
     fn test_overflow_one_bit_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0001)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = UInt128Gadget::constant(2).value().unwrap();
 
         let result = byte
@@ -319,8 +381,8 @@ mod tests {
     fn test_overflow_all_bits_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 128;
-        let expected_byte = 0;
+        let positions_to_shift = 128_i32;
+        let expected_byte = 0_u128;
 
         let result = byte
             .shift_left(positions_to_shift.try_into().unwrap(), cs.clone())
@@ -335,7 +397,7 @@ mod tests {
     fn test_one_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(2)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = byte.value().unwrap() >> positions_to_shift;
 
         let result = byte
@@ -350,7 +412,7 @@ mod tests {
     fn test_more_than_one_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(4)).unwrap();
-        let positions_to_shift = 2;
+        let positions_to_shift = 2_i32;
         let expected_byte = byte.value().unwrap() >> positions_to_shift;
 
         let result = byte
@@ -365,7 +427,7 @@ mod tests {
     fn test_overflow_one_bit_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = UInt128Gadget::constant(0).value().unwrap();
 
         let result = byte
@@ -380,8 +442,8 @@ mod tests {
     fn test_overflow_all_bits_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt128Gadget::new_witness(cs.clone(), || Ok(u128::MAX)).unwrap();
-        let positions_to_shift = 128;
-        let expected_byte = 0;
+        let positions_to_shift = 128_i32;
+        let expected_byte = 0_u128;
 
         let result = byte
             .shift_right(positions_to_shift.try_into().unwrap(), cs.clone())

--- a/src/gadgets/uint32.rs
+++ b/src/gadgets/uint32.rs
@@ -1,6 +1,5 @@
-use super::traits::{
-    BitRotationGadget, BitShiftGadget, FromBytesGadget, IsWitness, ToFieldElements,
-};
+use super::helpers::zip_bits_and_apply;
+use super::traits::{BitwiseOperationGadget, FromBytesGadget, IsWitness, ToFieldElements};
 use anyhow::Result;
 use ark_ff::Field;
 use ark_r1cs_std::{
@@ -59,7 +58,72 @@ impl<F: Field> FromBytesGadget<F> for UInt32<F> {
     }
 }
 
-impl<F: Field> BitRotationGadget<F> for UInt32<F> {
+impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
+    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| first_bit.and(&second_bit),
+        )?;
+        let new_value = UInt32::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
+        )?;
+        let new_value = UInt32::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
+        )?;
+        let new_value = UInt32::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| first_bit.or(&second_bit),
+        )?;
+        let new_value = UInt32::from_bits_le(&result);
+        Ok(new_value)
+    }
+
+    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized + ToBitsGadget<F>,
+    {
+        let result = zip_bits_and_apply(
+            self.to_bits_le(),
+            other_gadget.to_bits_le()?,
+            |first_bit, second_bit| first_bit.xor(&second_bit),
+        )?;
+        let new_value = UInt32::from_bits_le(&result);
+        Ok(new_value)
+    }
+
     fn rotate_left(
         &self,
         positions: usize,
@@ -71,10 +135,13 @@ impl<F: Field> BitRotationGadget<F> for UInt32<F> {
         rotated_bits.rotate_left(positions);
 
         for i in 0..32 {
-            let a = &primitive_bits[(i + positions) % 32];
-            let b = &rotated_bits[i];
-            let c = lc!() + a.lc() - b.lc();
-            constraint_system.enforce_constraint(lc!(), lc!(), c)?
+            if let (Some(a), Some(b)) = (
+                &primitive_bits.get((i + positions) % 32),
+                &rotated_bits.get(i),
+            ) {
+                let c = lc!() + a.lc() - b.lc();
+                constraint_system.enforce_constraint(lc!(), lc!(), c)?
+            }
         }
 
         rotated_bits.reverse();
@@ -92,9 +159,7 @@ impl<F: Field> BitRotationGadget<F> for UInt32<F> {
         // tries to rotate more then 32 positions.
         self.rotate_left(32 - (positions % 32), constraint_system)
     }
-}
 
-impl<F: Field> BitShiftGadget<F> for UInt32<F> {
     fn shift_left(
         &self,
         positions: usize,
@@ -199,10 +264,7 @@ impl<F: Field> BitShiftGadget<F> for UInt32<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::gadgets::{
-        traits::{BitRotationGadget, BitShiftGadget},
-        ConstraintF, UInt32Gadget,
-    };
+    use crate::gadgets::{traits::BitwiseOperationGadget, ConstraintF, UInt32Gadget};
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 
@@ -281,7 +343,7 @@ mod tests {
     fn test_one_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = byte.value().unwrap() << positions_to_shift;
 
         let result = byte
@@ -296,7 +358,7 @@ mod tests {
     fn test_more_than_one_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 2;
+        let positions_to_shift = 2_i32;
         let expected_byte = byte.value().unwrap() << positions_to_shift;
 
         let result = byte
@@ -313,7 +375,7 @@ mod tests {
         let byte =
             UInt32Gadget::new_witness(cs.clone(), || Ok(0b1000_0000_0000_0000_0000_0000_0000_0001))
                 .unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = UInt32Gadget::constant(2).value().unwrap();
 
         let result = byte
@@ -328,7 +390,7 @@ mod tests {
     fn test_overflow_all_bits_left_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 32;
+        let positions_to_shift = 32_i32;
         let expected_byte = 0;
 
         let result = byte
@@ -344,7 +406,7 @@ mod tests {
     fn test_one_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(2)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = byte.value().unwrap() >> positions_to_shift;
 
         let result = byte
@@ -359,7 +421,7 @@ mod tests {
     fn test_more_than_one_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(4)).unwrap();
-        let positions_to_shift = 2;
+        let positions_to_shift = 2_i32;
         let expected_byte = byte.value().unwrap() >> positions_to_shift;
 
         let result = byte
@@ -374,7 +436,7 @@ mod tests {
     fn test_overflow_one_bit_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(1)).unwrap();
-        let positions_to_shift = 1;
+        let positions_to_shift = 1_i32;
         let expected_byte = UInt32Gadget::constant(0).value().unwrap();
 
         let result = byte
@@ -389,8 +451,8 @@ mod tests {
     fn test_overflow_all_bits_right_shift() {
         let cs = ConstraintSystem::<ConstraintF>::new_ref();
         let byte = UInt32Gadget::new_witness(cs.clone(), || Ok(u32::MAX)).unwrap();
-        let positions_to_shift = 32;
-        let expected_byte = 0;
+        let positions_to_shift = 32_i32;
+        let expected_byte = 0_u32;
 
         let result = byte
             .shift_right(positions_to_shift.try_into().unwrap(), cs.clone())

--- a/src/merkle_tree/simple_merkle_tree.rs
+++ b/src/merkle_tree/simple_merkle_tree.rs
@@ -198,7 +198,6 @@ pub fn check_leave_exists_u8<L: ToBytes>(
         .is_satisfied()
         .map_err(|_e| anyhow!("Error checking if the constrinaints are satisfied"))?;
 
-    println!("Hello world!");
     Ok(is_satisfied)
 }
 
@@ -209,6 +208,7 @@ mod tests {
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
     use bitvec::array::BitArray;
 
+    #[allow(clippy::print_stdout)]
     #[test]
     fn bit_test() {
         let bits = BitArray::<u8>::from(254);


### PR DESCRIPTION
This PR contains a new gadget for bitwise operations which includes the following functions: 
- `and`
- `nand`
- `nor`
- `or`
- `xor`
- `right_shift`
- `left_shift`
- `rotate_right`
- `rotate_left`

The last four were already implemented in other gadgets so I removed them and move those functions to this new gadget. All new functions were implemented for `u8`, `u16`, `u32`, `u64` and `u128` types.