### PR TITLE
Fix bitwise operations gadget 

### DIFF
--- a/src/gadgets/traits.rs
+++ b/src/gadgets/traits.rs
@@ -59,23 +59,23 @@ pub trait ByteRotationGadget<F: Field> {
 }
 
 pub trait BitwiseOperationGadget<F: Field> {
-    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn and(&self, other_gadget: Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn or(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>;
 
-    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nand(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>;
 
-    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nor(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>;
 
-    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
-    where
-        Self: std::marker::Sized + ToBitsGadget<F>;
-
-    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn xor(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>;
 

--- a/src/gadgets/uint128.rs
+++ b/src/gadgets/uint128.rs
@@ -59,65 +59,65 @@ impl<F: Field> FromBytesGadget<F> for UInt128<F> {
 }
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
-    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn and(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
         )?;
         let new_value = UInt128::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nand(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
         )?;
         let new_value = UInt128::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nor(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
         )?;
         let new_value = UInt128::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn or(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
         )?;
         let new_value = UInt128::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn xor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
         )?;
         let new_value = UInt128::from_bits_le(&result);

--- a/src/gadgets/uint16.rs
+++ b/src/gadgets/uint16.rs
@@ -29,16 +29,6 @@ impl<F: Field> ToFieldElements<F> for UInt16<F> {
     }
 }
 
-// impl<F: Field> ToBitsGadget<F> for UInt16<F> {
-//     fn to_bits_be(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
-//         self.to_bits_be()
-//     }
-
-//     fn to_bits_le(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
-//         Ok(self.to_bits_le())
-//     }
-// }
-
 impl<F: Field> FromBytesGadget<F> for UInt16<F> {
     fn from_bytes_le(bytes: &[UInt8<F>]) -> Result<Self>
     where

--- a/src/gadgets/uint16.rs
+++ b/src/gadgets/uint16.rs
@@ -29,6 +29,16 @@ impl<F: Field> ToFieldElements<F> for UInt16<F> {
     }
 }
 
+// impl<F: Field> ToBitsGadget<F> for UInt16<F> {
+//     fn to_bits_be(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
+//         self.to_bits_be()
+//     }
+
+//     fn to_bits_le(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
+//         Ok(self.to_bits_le())
+//     }
+// }
+
 impl<F: Field> FromBytesGadget<F> for UInt16<F> {
     fn from_bytes_le(bytes: &[UInt8<F>]) -> Result<Self>
     where
@@ -59,65 +69,65 @@ impl<F: Field> FromBytesGadget<F> for UInt16<F> {
 impl<F: Field> IsWitness<F> for UInt16<F> {}
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt16<F> {
-    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn and(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
         )?;
         let new_value = UInt16::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nand(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
         )?;
         let new_value = UInt16::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
         )?;
         let new_value = UInt16::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn or(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
         )?;
         let new_value = UInt16::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn xor(&self, other_gadget: Self) -> Result<Self>
     where
         Self: std::marker::Sized + ToBitsGadget<F>,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
         )?;
         let new_value = UInt16::from_bits_le(&result);

--- a/src/gadgets/uint32.rs
+++ b/src/gadgets/uint32.rs
@@ -59,65 +59,65 @@ impl<F: Field> FromBytesGadget<F> for UInt32<F> {
 }
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
-    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn and(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
         )?;
         let new_value = UInt32::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nand(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
         )?;
         let new_value = UInt32::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
         )?;
         let new_value = UInt32::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn or(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
         )?;
         let new_value = UInt32::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn xor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
         )?;
         let new_value = UInt32::from_bits_le(&result);

--- a/src/gadgets/uint64.rs
+++ b/src/gadgets/uint64.rs
@@ -59,65 +59,65 @@ impl<F: Field> FromBytesGadget<F> for UInt64<F> {
 }
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
-    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn and(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
         )?;
         let new_value = UInt64::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nand(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
         )?;
         let new_value = UInt64::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
         )?;
         let new_value = UInt64::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn or(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
         )?;
         let new_value = UInt64::from_bits_le(&result);
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn xor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le(),
-            other_gadget.to_bits_le()?,
+            other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
         )?;
         let new_value = UInt64::from_bits_le(&result);

--- a/src/gadgets/uint8.rs
+++ b/src/gadgets/uint8.rs
@@ -27,9 +27,9 @@ impl<F: Field> ToFieldElements<F> for UInt8<F> {
 impl<F: Field> IsWitness<F> for [UInt8<F>] {}
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
-    fn and(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn and(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le()?,
@@ -40,9 +40,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nand(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le()?,
@@ -53,9 +53,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn nor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le()?,
@@ -66,9 +66,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn or(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le()?,
@@ -79,9 +79,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: impl BitwiseOperationGadget<F> + ToBitsGadget<F>) -> Result<Self>
+    fn xor(&self, other_gadget: Self) -> Result<Self>
     where
-        Self: std::marker::Sized + ToBitsGadget<F>,
+        Self: std::marker::Sized,
     {
         let result = zip_bits_and_apply(
             self.to_bits_le()?,


### PR DESCRIPTION
The `u16`, `u32`, `u64` and `u128` types does not implement the `ToBitsGadget` trait. To use functions like `to_bits_le()`, necessary for all the functions in the `BitwiseOperationGadget` trait, I removed the condition for functions parameter to have the `ToBitsGadget` trait implemented, instead each function receive a parameter of type `Self`. 