### PR TITLE
Implementation for arithmetic and comparison gadgets

### DIFF
--- a/src/gadgets/boolean.rs
+++ b/src/gadgets/boolean.rs
@@ -1,4 +1,5 @@
-use super::traits::IsWitness;
+use super::traits::{BitwiseOperationGadget, IsWitness};
+use anyhow::anyhow;
 use ark_ff::Field;
 use ark_r1cs_std::prelude::Boolean;
 
@@ -14,5 +15,42 @@ impl<F: Field> IsWitness<F> for Boolean<F> {
         } else {
             Ok(false)
         }
+    }
+}
+
+impl<F: Field> BitwiseOperationGadget<F> for Boolean<F> {
+    fn and(&self, other_gadget: &Self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        self.and(other_gadget).map_err(|e| anyhow!(e))
+    }
+
+    fn nand(&self, other_gadget: &Self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Boolean::kary_nand(&[self.clone(), other_gadget.clone()]).map_err(|e| anyhow!(e))
+    }
+
+    fn nor(&self, other_gadget: &Self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(self.or(other_gadget)?.not())
+    }
+
+    fn or(&self, other_gadget: &Self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        self.or(other_gadget).map_err(|e| anyhow!(e))
+    }
+
+    fn xor(&self, other_gadget: &Self) -> anyhow::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        self.xor(other_gadget).map_err(|e| anyhow!(e))
     }
 }

--- a/src/gadgets/helpers.rs
+++ b/src/gadgets/helpers.rs
@@ -1,9 +1,31 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use ark_ff::Field;
-use ark_r1cs_std::prelude::Boolean;
-use ark_relations::r1cs::SynthesisError;
+use ark_r1cs_std::{
+    prelude::{AllocVar, Boolean},
+    select::CondSelectGadget,
+    R1CSVar,
+};
+use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 
-pub fn zip_bits_and_apply<F: Field, T>(
+pub enum Comparison {
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThanOrEqual,
+    LessThan,
+}
+
+impl Comparison {
+    pub fn instruction(&self) -> &str {
+        match self {
+            Comparison::GreaterThan => "gt",
+            Comparison::GreaterThanOrEqual => "gte",
+            Comparison::LessThanOrEqual => "lte",
+            Comparison::LessThan => "lt",
+        }
+    }
+}
+
+pub(crate) fn zip_bits_and_apply<F: Field, T>(
     first_bits_to_iterate: Vec<Boolean<F>>,
     second_bits_to_iterate: Vec<Boolean<F>>,
     function_to_apply: T,
@@ -21,4 +43,31 @@ where
         result.push(operation_result);
     }
     Ok(result)
+}
+
+pub(crate) fn compare_ord<F: Field, T: R1CSVar<F>>(
+    left_operand: T,
+    right_operand: T,
+    comparison: Comparison,
+    constraint_system: ConstraintSystemRef<F>,
+) -> Result<Boolean<F>>
+where
+    T::Value: PartialOrd,
+{
+    let result = match comparison {
+        Comparison::GreaterThan => left_operand.value()? > right_operand.value()?,
+        Comparison::GreaterThanOrEqual => left_operand.value()? >= right_operand.value()?,
+        Comparison::LessThanOrEqual => left_operand.value()? <= right_operand.value()?,
+        Comparison::LessThan => left_operand.value()? < right_operand.value()?,
+    };
+
+    let true_witness = Boolean::<F>::new_witness(constraint_system.clone(), || Ok(true))?;
+    let false_witness = Boolean::<F>::new_witness(constraint_system.clone(), || Ok(false))?;
+
+    Boolean::conditionally_select(
+        &Boolean::new_witness(constraint_system, || Ok(result))?,
+        &true_witness,
+        &false_witness,
+    )
+    .map_err(|error| anyhow!(error))
 }

--- a/src/gadgets/mod.rs
+++ b/src/gadgets/mod.rs
@@ -24,6 +24,7 @@ mod uint8;
 pub mod traits;
 
 pub type ConstraintF = ark_ed_on_bls12_377::Fq;
+pub type Comparison = helpers::Comparison;
 
 pub type UInt8Gadget = UInt8<ConstraintF>;
 pub type UInt16Gadget = UInt16<ConstraintF>;

--- a/src/gadgets/traits.rs
+++ b/src/gadgets/traits.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use ark_ff::Field;
-use ark_r1cs_std::{uint8::UInt8, ToBitsGadget, ToBytesGadget};
+use ark_r1cs_std::{prelude::Boolean, uint8::UInt8, ToBitsGadget, ToBytesGadget};
 use ark_relations::r1cs::ConstraintSystemRef;
+
+use super::Comparison;
 
 pub trait ToFieldElements<F: Field> {
     fn to_field_elements(&self) -> Result<Vec<F>>;
@@ -128,6 +130,17 @@ pub trait ArithmeticGadget<F: Field> {
         Self: std::marker::Sized;
 
     fn div(&self, divisor: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+}
+
+pub trait ComparisonGadget<F: Field> {
+    fn compare(
+        &self,
+        gadget_to_compare: &Self,
+        comparison: Comparison,
+        constraint_system: ConstraintSystemRef<F>,
+    ) -> Result<Boolean<F>>
     where
         Self: std::marker::Sized;
 }

--- a/src/gadgets/traits.rs
+++ b/src/gadgets/traits.rs
@@ -40,7 +40,7 @@ pub trait FromBytesGadget<F: Field> {
         Self: Sized;
 }
 
-pub trait ByteRotationGadget<F: Field> {
+pub trait ByteManipulationGadget<F: Field> {
     fn rotate_left(
         &self,
         positions: usize,
@@ -58,27 +58,7 @@ pub trait ByteRotationGadget<F: Field> {
         Self: std::marker::Sized;
 }
 
-pub trait BitwiseOperationGadget<F: Field> {
-    fn and(&self, other_gadget: Self) -> Result<Self>
-    where
-        Self: std::marker::Sized;
-
-    fn or(&self, other_gadget: Self) -> Result<Self>
-    where
-        Self: std::marker::Sized;
-
-    fn nand(&self, other_gadget: Self) -> Result<Self>
-    where
-        Self: std::marker::Sized;
-
-    fn nor(&self, other_gadget: Self) -> Result<Self>
-    where
-        Self: std::marker::Sized;
-
-    fn xor(&self, other_gadget: Self) -> Result<Self>
-    where
-        Self: std::marker::Sized;
-
+pub trait BitManipulationGadget<F: Field> {
     fn shift_left(
         &self,
         positions: usize,
@@ -108,6 +88,46 @@ pub trait BitwiseOperationGadget<F: Field> {
         positions: usize,
         constraint_system: ConstraintSystemRef<F>,
     ) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+}
+
+pub trait BitwiseOperationGadget<F: Field> {
+    fn and(&self, other_gadget: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn or(&self, other_gadget: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn nand(&self, other_gadget: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn nor(&self, other_gadget: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn xor(&self, other_gadget: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+}
+
+pub trait ArithmeticGadget<F: Field> {
+    fn add(&self, addend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn sub(&self, subtrahend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn mul(&self, multiplicand: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn div(&self, divisor: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
     where
         Self: std::marker::Sized;
 }

--- a/src/gadgets/uint128.rs
+++ b/src/gadgets/uint128.rs
@@ -1,7 +1,10 @@
 use super::helpers::zip_bits_and_apply;
-use super::traits::{BitwiseOperationGadget, FromBytesGadget, IsWitness, ToFieldElements};
-use anyhow::Result;
-use ark_ff::Field;
+use super::traits::{
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
+    ToFieldElements,
+};
+use anyhow::{ensure, Result};
+use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
     prelude::{AllocVar, Boolean},
     uint128::UInt128,
@@ -12,6 +15,8 @@ use ark_relations::{
     lc,
     r1cs::{ConstraintSystemRef, SynthesisError},
 };
+
+use ark_r1cs_std::select::CondSelectGadget;
 
 impl<F: Field> ToFieldElements<F> for UInt128<F> {
     fn to_field_elements(&self) -> Result<Vec<F>> {
@@ -59,7 +64,7 @@ impl<F: Field> FromBytesGadget<F> for UInt128<F> {
 }
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
-    fn and(&self, other_gadget: Self) -> Result<Self>
+    fn and(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -72,7 +77,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: Self) -> Result<Self>
+    fn nand(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -85,7 +90,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: Self) -> Result<Self>
+    fn nor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -98,7 +103,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: Self) -> Result<Self>
+    fn or(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -111,7 +116,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: Self) -> Result<Self>
+    fn xor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -123,7 +128,100 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
         let new_value = UInt128::from_bits_le(&result);
         Ok(new_value)
     }
+}
 
+impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt128<F> {
+    fn add(&self, addend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let result = Self::addmany(&[self.clone(), addend.clone()])?;
+        Ok(result)
+    }
+
+    fn sub(&self, subtrahend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(
+            self.value()? >= subtrahend.value()?,
+            "Subtraction underflow"
+        );
+
+        let minuend_as_augend = Self::from_bits_le(
+            &(self
+                .to_bits_le()
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>()),
+        );
+        let subtrahend_as_addend = subtrahend.to_bits_le();
+
+        let subtrahend_as_addend_var = Self::from_bits_le(&subtrahend_as_addend);
+
+        let partial_result = Self::addmany(&[minuend_as_augend, subtrahend_as_addend_var])?;
+
+        let difference = Self::from_bits_le(
+            &partial_result
+                .to_bits_le()
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>(),
+        );
+
+        Ok(difference)
+    }
+
+    fn div(&self, divisor: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(divisor.value()? != 0_u128, "attempt to divide by zero");
+        let mut quotient = self.clone();
+        let mut aux = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+
+        let one = Self::new_constant(constraint_system.clone(), 1)?;
+
+        for dividend_bit in self.to_bits_le().iter().rev() {
+            quotient = quotient.shift_left(1, constraint_system.clone())?;
+            aux = Self::conditionally_select(
+                dividend_bit,
+                &aux.shift_left(1, constraint_system.clone())?.or(&one)?,
+                &aux.shift_left(1, constraint_system.clone())?,
+            )?;
+
+            // FIXME USE REAL COMPARISON
+            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+
+            quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
+            aux = if is_greater == Boolean::TRUE {
+                aux
+            } else {
+                aux.sub(divisor)?
+            }
+        }
+        Ok(quotient)
+    }
+
+    fn mul(&self, multiplicand: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut product = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+        for (i, multiplier_bit) in self.to_bits_le().iter().enumerate() {
+            // If the multiplier bit is a 1.
+            let addend = multiplicand.shift_left(i, constraint_system.clone())?;
+            product = Self::conditionally_select(
+                multiplier_bit,
+                &Self::addmany(&[product.clone(), addend])?,
+                &product,
+            )?;
+        }
+        Ok(product)
+    }
+}
+
+impl<F: Field> BitManipulationGadget<F> for UInt128<F> {
     fn rotate_left(
         &self,
         positions: usize,
@@ -264,7 +362,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::gadgets::{traits::BitwiseOperationGadget, ConstraintF, UInt128Gadget};
+    use crate::gadgets::{traits::BitManipulationGadget, ConstraintF, UInt128Gadget};
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 

--- a/src/gadgets/uint128.rs
+++ b/src/gadgets/uint128.rs
@@ -191,11 +191,11 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt128<F> {
                 &aux.shift_left(1, constraint_system.clone())?,
             )?;
 
-            // FIXME USE REAL COMPARISON
-            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+            let is_greater =
+                divisor.compare(&aux, Comparison::GreaterThan, constraint_system.clone())?;
 
             quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
-            aux = if is_greater == Boolean::TRUE {
+            aux = if is_greater.value()? {
                 aux
             } else {
                 aux.sub(divisor)?

--- a/src/gadgets/uint128.rs
+++ b/src/gadgets/uint128.rs
@@ -1,8 +1,9 @@
-use super::helpers::zip_bits_and_apply;
+use super::helpers;
 use super::traits::{
-    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
-    ToFieldElements,
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, ComparisonGadget,
+    FromBytesGadget, IsWitness, ToFieldElements,
 };
+use super::Comparison;
 use anyhow::{ensure, Result};
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
@@ -68,7 +69,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
@@ -81,7 +82,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
@@ -94,7 +95,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
@@ -107,7 +108,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
@@ -120,7 +121,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt128<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
@@ -218,6 +219,20 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt128<F> {
             )?;
         }
         Ok(product)
+    }
+}
+
+impl<F: Field> ComparisonGadget<F> for UInt128<F> {
+    fn compare(
+        &self,
+        gadget_to_compare: &Self,
+        comparison: Comparison,
+        constraint_system: ConstraintSystemRef<F>,
+    ) -> Result<Boolean<F>>
+    where
+        Self: std::marker::Sized,
+    {
+        helpers::compare_ord(self, gadget_to_compare, comparison, constraint_system)
     }
 }
 

--- a/src/gadgets/uint16.rs
+++ b/src/gadgets/uint16.rs
@@ -329,11 +329,11 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt16<F> {
                 &aux.shift_left(1, constraint_system.clone())?,
             )?;
 
-            // FIXME USE REAL COMPARISON
-            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+            let is_greater =
+                divisor.compare(&aux, Comparison::GreaterThan, constraint_system.clone())?;
 
             quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
-            aux = if is_greater == Boolean::TRUE {
+            aux = if is_greater.value()? {
                 aux
             } else {
                 aux.sub(divisor)?

--- a/src/gadgets/uint16.rs
+++ b/src/gadgets/uint16.rs
@@ -1,8 +1,9 @@
-use super::helpers::zip_bits_and_apply;
+use super::helpers;
 use super::traits::{
-    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
-    ToFieldElements,
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, ComparisonGadget,
+    FromBytesGadget, IsWitness, ToFieldElements,
 };
+use super::Comparison;
 use anyhow::{ensure, Result};
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
@@ -68,7 +69,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt16<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
@@ -81,7 +82,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt16<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
@@ -94,7 +95,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt16<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
@@ -107,7 +108,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt16<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
@@ -120,7 +121,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt16<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
@@ -356,6 +357,20 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt16<F> {
             )?;
         }
         Ok(product)
+    }
+}
+
+impl<F: Field> ComparisonGadget<F> for UInt16<F> {
+    fn compare(
+        &self,
+        gadget_to_compare: &Self,
+        comparison: Comparison,
+        constraint_system: ConstraintSystemRef<F>,
+    ) -> Result<Boolean<F>>
+    where
+        Self: std::marker::Sized,
+    {
+        helpers::compare_ord(self, gadget_to_compare, comparison, constraint_system)
     }
 }
 

--- a/src/gadgets/uint32.rs
+++ b/src/gadgets/uint32.rs
@@ -1,8 +1,9 @@
-use super::helpers::zip_bits_and_apply;
+use super::helpers;
 use super::traits::{
-    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
-    ToFieldElements,
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, ComparisonGadget,
+    FromBytesGadget, IsWitness, ToFieldElements,
 };
+use super::Comparison;
 use anyhow::{ensure, Result};
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
@@ -68,7 +69,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
@@ -81,7 +82,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
@@ -94,7 +95,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
@@ -107,7 +108,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
@@ -120,7 +121,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
@@ -357,6 +358,20 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt32<F> {
             )?;
         }
         Ok(product)
+    }
+}
+
+impl<F: Field> ComparisonGadget<F> for UInt32<F> {
+    fn compare(
+        &self,
+        gadget_to_compare: &Self,
+        comparison: Comparison,
+        constraint_system: ConstraintSystemRef<F>,
+    ) -> Result<Boolean<F>>
+    where
+        Self: std::marker::Sized,
+    {
+        helpers::compare_ord(self, gadget_to_compare, comparison, constraint_system)
     }
 }
 

--- a/src/gadgets/uint32.rs
+++ b/src/gadgets/uint32.rs
@@ -330,11 +330,11 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt32<F> {
                 &aux.shift_left(1, constraint_system.clone())?,
             )?;
 
-            // FIXME USE REAL COMPARISON
-            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+            let is_greater =
+                divisor.compare(&aux, Comparison::GreaterThan, constraint_system.clone())?;
 
             quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
-            aux = if is_greater == Boolean::TRUE {
+            aux = if is_greater.value()? {
                 aux
             } else {
                 aux.sub(divisor)?

--- a/src/gadgets/uint32.rs
+++ b/src/gadgets/uint32.rs
@@ -1,7 +1,10 @@
 use super::helpers::zip_bits_and_apply;
-use super::traits::{BitwiseOperationGadget, FromBytesGadget, IsWitness, ToFieldElements};
-use anyhow::Result;
-use ark_ff::Field;
+use super::traits::{
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
+    ToFieldElements,
+};
+use anyhow::{ensure, Result};
+use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
     prelude::{AllocVar, Boolean},
     uint32::UInt32,
@@ -12,6 +15,8 @@ use ark_relations::{
     lc,
     r1cs::{ConstraintSystemRef, SynthesisError},
 };
+
+use ark_r1cs_std::select::CondSelectGadget;
 
 impl<F: Field> ToFieldElements<F> for UInt32<F> {
     fn to_field_elements(&self) -> Result<Vec<F>> {
@@ -59,7 +64,7 @@ impl<F: Field> FromBytesGadget<F> for UInt32<F> {
 }
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
-    fn and(&self, other_gadget: Self) -> Result<Self>
+    fn and(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -72,7 +77,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: Self) -> Result<Self>
+    fn nand(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -85,7 +90,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: Self) -> Result<Self>
+    fn nor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -98,7 +103,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: Self) -> Result<Self>
+    fn or(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -111,7 +116,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: Self) -> Result<Self>
+    fn xor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -123,7 +128,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
         let new_value = UInt32::from_bits_le(&result);
         Ok(new_value)
     }
+}
 
+impl<F: Field> BitManipulationGadget<F> for UInt32<F> {
     fn rotate_left(
         &self,
         positions: usize,
@@ -262,9 +269,100 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt32<F> {
     }
 }
 
+impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt32<F> {
+    fn add(&self, addend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let result = Self::addmany(&[self.clone(), addend.clone()])?;
+        Ok(result)
+    }
+
+    fn sub(&self, subtrahend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(
+            self.value()? >= subtrahend.value()?,
+            "Subtraction underflow"
+        );
+
+        let minuend_as_augend = Self::from_bits_le(
+            &(self
+                .to_bits_le()
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>()),
+        );
+        let subtrahend_as_addend = subtrahend.to_bits_le();
+
+        let subtrahend_as_addend_var = Self::from_bits_le(&subtrahend_as_addend);
+
+        let partial_result = Self::addmany(&[minuend_as_augend, subtrahend_as_addend_var])?;
+
+        let difference = Self::from_bits_le(
+            &partial_result
+                .to_bits_le()
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>(),
+        );
+
+        Ok(difference)
+    }
+
+    fn div(&self, divisor: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(divisor.value()? != 0_u32, "attempt to divide by zero");
+        let mut quotient = self.clone();
+        let mut aux = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+
+        let one = Self::new_constant(constraint_system.clone(), 1)?;
+
+        for dividend_bit in self.to_bits_le().iter().rev() {
+            quotient = quotient.shift_left(1, constraint_system.clone())?;
+            aux = Self::conditionally_select(
+                dividend_bit,
+                &aux.shift_left(1, constraint_system.clone())?.or(&one)?,
+                &aux.shift_left(1, constraint_system.clone())?,
+            )?;
+
+            // FIXME USE REAL COMPARISON
+            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+
+            quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
+            aux = if is_greater == Boolean::TRUE {
+                aux
+            } else {
+                aux.sub(divisor)?
+            }
+        }
+        Ok(quotient)
+    }
+
+    fn mul(&self, multiplicand: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut product = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+        for (i, multiplier_bit) in self.to_bits_le().iter().enumerate() {
+            // If the multiplier bit is a 1.
+            let addend = multiplicand.shift_left(i, constraint_system.clone())?;
+            product = Self::conditionally_select(
+                multiplier_bit,
+                &Self::addmany(&[product.clone(), addend])?,
+                &product,
+            )?;
+        }
+        Ok(product)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::gadgets::{traits::BitwiseOperationGadget, ConstraintF, UInt32Gadget};
+    use crate::gadgets::{traits::BitManipulationGadget, ConstraintF, UInt32Gadget};
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 

--- a/src/gadgets/uint64.rs
+++ b/src/gadgets/uint64.rs
@@ -1,8 +1,9 @@
-use super::helpers::zip_bits_and_apply;
+use super::helpers;
 use super::traits::{
-    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
-    ToFieldElements,
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, ComparisonGadget,
+    FromBytesGadget, IsWitness, ToFieldElements,
 };
+use super::Comparison;
 use anyhow::{ensure, Result};
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
@@ -68,7 +69,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.and(&second_bit),
@@ -81,7 +82,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
@@ -94,7 +95,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
@@ -107,7 +108,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.or(&second_bit),
@@ -120,7 +121,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le(),
             other_gadget.to_bits_le(),
             |first_bit, second_bit| first_bit.xor(&second_bit),
@@ -357,6 +358,20 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt64<F> {
             )?;
         }
         Ok(product)
+    }
+}
+
+impl<F: Field> ComparisonGadget<F> for UInt64<F> {
+    fn compare(
+        &self,
+        gadget_to_compare: &Self,
+        comparison: Comparison,
+        constraint_system: ConstraintSystemRef<F>,
+    ) -> Result<Boolean<F>>
+    where
+        Self: std::marker::Sized,
+    {
+        helpers::compare_ord(self, gadget_to_compare, comparison, constraint_system)
     }
 }
 

--- a/src/gadgets/uint64.rs
+++ b/src/gadgets/uint64.rs
@@ -330,11 +330,11 @@ impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt64<F> {
                 &aux.shift_left(1, constraint_system.clone())?,
             )?;
 
-            // FIXME USE REAL COMPARISON
-            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+            let is_greater =
+                divisor.compare(&aux, Comparison::GreaterThan, constraint_system.clone())?;
 
             quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
-            aux = if is_greater == Boolean::TRUE {
+            aux = if is_greater.value()? {
                 aux
             } else {
                 aux.sub(divisor)?

--- a/src/gadgets/uint64.rs
+++ b/src/gadgets/uint64.rs
@@ -1,7 +1,10 @@
 use super::helpers::zip_bits_and_apply;
-use super::traits::{BitwiseOperationGadget, FromBytesGadget, IsWitness, ToFieldElements};
-use anyhow::Result;
-use ark_ff::Field;
+use super::traits::{
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, FromBytesGadget, IsWitness,
+    ToFieldElements,
+};
+use anyhow::{ensure, Result};
+use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
     prelude::{AllocVar, Boolean},
     uint64::UInt64,
@@ -12,6 +15,8 @@ use ark_relations::{
     lc,
     r1cs::{ConstraintSystemRef, SynthesisError},
 };
+
+use ark_r1cs_std::select::CondSelectGadget;
 
 impl<F: Field> ToFieldElements<F> for UInt64<F> {
     fn to_field_elements(&self) -> Result<Vec<F>> {
@@ -59,7 +64,7 @@ impl<F: Field> FromBytesGadget<F> for UInt64<F> {
 }
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
-    fn and(&self, other_gadget: Self) -> Result<Self>
+    fn and(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -72,7 +77,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: Self) -> Result<Self>
+    fn nand(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -85,7 +90,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: Self) -> Result<Self>
+    fn nor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -98,7 +103,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: Self) -> Result<Self>
+    fn or(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -111,7 +116,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: Self) -> Result<Self>
+    fn xor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -123,7 +128,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
         let new_value = UInt64::from_bits_le(&result);
         Ok(new_value)
     }
+}
 
+impl<F: Field> BitManipulationGadget<F> for UInt64<F> {
     fn rotate_left(
         &self,
         positions: usize,
@@ -262,9 +269,100 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt64<F> {
     }
 }
 
+impl<F: Field + PrimeField> ArithmeticGadget<F> for UInt64<F> {
+    fn add(&self, addend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let result = Self::addmany(&[self.clone(), addend.clone()])?;
+        Ok(result)
+    }
+
+    fn sub(&self, subtrahend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(
+            self.value()? >= subtrahend.value()?,
+            "Subtraction underflow"
+        );
+
+        let minuend_as_augend = Self::from_bits_le(
+            &(self
+                .to_bits_le()
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>()),
+        );
+        let subtrahend_as_addend = subtrahend.to_bits_le();
+
+        let subtrahend_as_addend_var = Self::from_bits_le(&subtrahend_as_addend);
+
+        let partial_result = Self::addmany(&[minuend_as_augend, subtrahend_as_addend_var])?;
+
+        let difference = Self::from_bits_le(
+            &partial_result
+                .to_bits_le()
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>(),
+        );
+
+        Ok(difference)
+    }
+
+    fn div(&self, divisor: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(divisor.value()? != 0_u64, "attempt to divide by zero");
+        let mut quotient = self.clone();
+        let mut aux = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+
+        let one = Self::new_constant(constraint_system.clone(), 1)?;
+
+        for dividend_bit in self.to_bits_le().iter().rev() {
+            quotient = quotient.shift_left(1, constraint_system.clone())?;
+            aux = Self::conditionally_select(
+                dividend_bit,
+                &aux.shift_left(1, constraint_system.clone())?.or(&one)?,
+                &aux.shift_left(1, constraint_system.clone())?,
+            )?;
+
+            // FIXME USE REAL COMPARISON
+            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+
+            quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
+            aux = if is_greater == Boolean::TRUE {
+                aux
+            } else {
+                aux.sub(divisor)?
+            }
+        }
+        Ok(quotient)
+    }
+
+    fn mul(&self, multiplicand: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut product = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+        for (i, multiplier_bit) in self.to_bits_le().iter().enumerate() {
+            // If the multiplier bit is a 1.
+            let addend = multiplicand.shift_left(i, constraint_system.clone())?;
+            product = Self::conditionally_select(
+                multiplier_bit,
+                &Self::addmany(&[product.clone(), addend])?,
+                &product,
+            )?;
+        }
+        Ok(product)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::gadgets::{traits::BitwiseOperationGadget, ConstraintF, UInt64Gadget};
+    use crate::gadgets::{traits::BitManipulationGadget, ConstraintF, UInt64Gadget};
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 

--- a/src/gadgets/uint8.rs
+++ b/src/gadgets/uint8.rs
@@ -1,7 +1,12 @@
 use super::helpers::zip_bits_and_apply;
-use super::traits::{BitwiseOperationGadget, ByteRotationGadget, IsWitness, ToFieldElements};
-use anyhow::Result;
+use super::traits::{
+    ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, ByteManipulationGadget,
+    IsWitness, ToFieldElements,
+};
+use anyhow::{anyhow, ensure, Result};
 use ark_ff::Field;
+use ark_r1cs_std::prelude::Boolean;
+use ark_r1cs_std::select::CondSelectGadget;
 use ark_r1cs_std::{prelude::AllocVar, uint8::UInt8, R1CSVar, ToBitsGadget};
 use ark_relations::{
     lc,
@@ -27,7 +32,7 @@ impl<F: Field> ToFieldElements<F> for UInt8<F> {
 impl<F: Field> IsWitness<F> for [UInt8<F>] {}
 
 impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
-    fn and(&self, other_gadget: Self) -> Result<Self>
+    fn and(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -40,7 +45,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn nand(&self, other_gadget: Self) -> Result<Self>
+    fn nand(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -53,7 +58,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn nor(&self, other_gadget: Self) -> Result<Self>
+    fn nor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -66,7 +71,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn or(&self, other_gadget: Self) -> Result<Self>
+    fn or(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -79,7 +84,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         Ok(new_value)
     }
 
-    fn xor(&self, other_gadget: Self) -> Result<Self>
+    fn xor(&self, other_gadget: &Self) -> Result<Self>
     where
         Self: std::marker::Sized,
     {
@@ -91,7 +96,9 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
         let new_value = UInt8::from_bits_le(&result);
         Ok(new_value)
     }
+}
 
+impl<F: Field> BitManipulationGadget<F> for UInt8<F> {
     fn rotate_left(
         &self,
         positions: usize,
@@ -225,7 +232,117 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
     }
 }
 
-impl<F: Field> ByteRotationGadget<F> for [UInt8<F>; 4] {
+impl<F: Field> ArithmeticGadget<F> for UInt8<F> {
+    fn add(&self, addend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let addend = addend.to_bits_le()?;
+        let augend = self.clone().to_bits_le()?;
+        let mut sum = vec![Boolean::<F>::FALSE; augend.len()];
+        let mut carry = Boolean::<F>::FALSE;
+        for (i, (augend_bit, addend_bit)) in augend.iter().zip(addend).enumerate() {
+            // Bit by bit sum is an xor for the augend, the addend and the carry bits.
+            // carry in | addend | augend | carry out | augend + addend |
+            //     0    |    0   |   0    |     0     |        0        |
+            //     0    |    0   |   1    |     0     |        1        |
+            //     0    |    1   |   0    |     0     |        1        |
+            //     0    |    1   |   1    |     1     |        0        |
+            //     1    |    0   |   0    |     0     |        1        |
+            //     1    |    0   |   1    |     1     |        0        |
+            //     1    |    1   |   0    |     1     |        0        |
+            //     1    |    1   |   1    |     1     |        1        |
+            // sum[i] = (!carry & (augend_bit ^ addend_bit)) | (carry & !(augend_bit ^ addend_bit))
+            //        = augend_bit ^ addend_bit ^ carry
+            *sum.get_mut(i)
+                .ok_or_else(|| anyhow!("Error accessing the index of sum"))? =
+                carry.xor(augend_bit)?.xor(&addend_bit)?;
+            // To simplify things, the variable carry acts for both the carry in and
+            // the carry out.
+            // The carry out is augend & addend when the carry in is 0, and it is
+            // augend | addend when the carry in is 1.
+            // carry = carry.not()
+            carry = (carry.not().and(&(augend_bit.and(&addend_bit)?))?)
+                .or(&(carry.and(&(augend_bit.or(&addend_bit)?))?))?;
+        }
+        let result = Self::from_bits_le(&sum);
+        Ok(result)
+    }
+
+    fn sub(&self, subtrahend: &Self) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(
+            self.value()? >= subtrahend.value()?,
+            "Subtraction underflow"
+        );
+        let minuend_as_augend = Self::from_bits_le(
+            &(self
+                .to_bits_le()?
+                .into_iter()
+                .map(|bit| bit.not())
+                .collect::<Vec<Boolean<F>>>()),
+        );
+
+        let partial_result = minuend_as_augend.add(subtrahend)?;
+
+        let difference = &partial_result
+            .to_bits_le()?
+            .into_iter()
+            .map(|bit| bit.not())
+            .collect::<Vec<Boolean<F>>>();
+
+        let result = Self::from_bits_le(difference);
+        Ok(result)
+    }
+
+    fn div(&self, divisor: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        ensure!(divisor.value()? != 0_u8, "attempt to divide by zero");
+        let mut quotient = self.clone();
+        let mut aux = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+
+        let one = Self::new_constant(constraint_system.clone(), 1)?;
+
+        for dividend_bit in self.to_bits_be()? {
+            quotient = quotient.shift_left(1, constraint_system.clone())?;
+            aux = Self::conditionally_select(
+                &dividend_bit,
+                &aux.shift_left(1, constraint_system.clone())?.or(&one)?,
+                &aux.shift_left(1, constraint_system.clone())?,
+            )?;
+
+            // FIXME USE REAL COMPARISON
+            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+
+            quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
+            aux = if is_greater == Boolean::TRUE {
+                aux
+            } else {
+                aux.sub(divisor)?
+            }
+        }
+        Ok(quotient)
+    }
+
+    fn mul(&self, multiplicand: &Self, constraint_system: ConstraintSystemRef<F>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut product = Self::new_witness(constraint_system.clone(), || Ok(0))?;
+        for (i, multiplier_bit) in self.to_bits_le()?.iter().enumerate() {
+            // If the multiplier bit is a 1.
+            let addend = Self::shift_left(multiplicand, i, constraint_system.clone())?;
+            product = Self::conditionally_select(multiplier_bit, &product.add(&addend)?, &product)?;
+        }
+        Ok(product)
+    }
+}
+
+impl<F: Field> ByteManipulationGadget<F> for [UInt8<F>; 4] {
     fn rotate_left(
         &self,
         positions: usize,
@@ -276,7 +393,7 @@ impl<F: Field> ByteRotationGadget<F> for [UInt8<F>; 4] {
 #[cfg(test)]
 mod uint8_tests {
     use crate::gadgets::{
-        traits::{BitwiseOperationGadget, ByteRotationGadget},
+        traits::{BitManipulationGadget, ByteManipulationGadget},
         ConstraintF, UInt8Gadget,
     };
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};

--- a/src/gadgets/uint8.rs
+++ b/src/gadgets/uint8.rs
@@ -316,11 +316,11 @@ impl<F: Field> ArithmeticGadget<F> for UInt8<F> {
                 &aux.shift_left(1, constraint_system.clone())?,
             )?;
 
-            // FIXME USE REAL COMPARISON
-            let is_greater = Boolean::constant(divisor.value()? > aux.value()?);
+            let is_greater =
+                divisor.compare(&aux, Comparison::GreaterThan, constraint_system.clone())?;
 
             quotient = Self::conditionally_select(&is_greater, &quotient, &quotient.or(&one)?)?;
-            aux = if is_greater == Boolean::TRUE {
+            aux = if is_greater.value()? {
                 aux
             } else {
                 aux.sub(divisor)?

--- a/src/gadgets/uint8.rs
+++ b/src/gadgets/uint8.rs
@@ -1,8 +1,9 @@
-use super::helpers::zip_bits_and_apply;
+use super::helpers;
 use super::traits::{
     ArithmeticGadget, BitManipulationGadget, BitwiseOperationGadget, ByteManipulationGadget,
-    IsWitness, ToFieldElements,
+    ComparisonGadget, IsWitness, ToFieldElements,
 };
+use super::Comparison;
 use anyhow::{anyhow, ensure, Result};
 use ark_ff::Field;
 use ark_r1cs_std::prelude::Boolean;
@@ -36,7 +37,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le()?,
             other_gadget.to_bits_le()?,
             |first_bit, second_bit| first_bit.and(&second_bit),
@@ -49,7 +50,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le()?,
             other_gadget.to_bits_le()?,
             |first_bit, second_bit| Ok(first_bit.and(&second_bit)?.not()),
@@ -62,7 +63,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le()?,
             other_gadget.to_bits_le()?,
             |first_bit, second_bit| Ok(first_bit.or(&second_bit)?.not()),
@@ -75,7 +76,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le()?,
             other_gadget.to_bits_le()?,
             |first_bit, second_bit| first_bit.or(&second_bit),
@@ -88,7 +89,7 @@ impl<F: Field> BitwiseOperationGadget<F> for UInt8<F> {
     where
         Self: std::marker::Sized,
     {
-        let result = zip_bits_and_apply(
+        let result = helpers::zip_bits_and_apply(
             self.to_bits_le()?,
             other_gadget.to_bits_le()?,
             |first_bit, second_bit| first_bit.xor(&second_bit),
@@ -339,6 +340,20 @@ impl<F: Field> ArithmeticGadget<F> for UInt8<F> {
             product = Self::conditionally_select(multiplier_bit, &product.add(&addend)?, &product)?;
         }
         Ok(product)
+    }
+}
+
+impl<F: Field> ComparisonGadget<F> for UInt8<F> {
+    fn compare(
+        &self,
+        gadget_to_compare: &Self,
+        comparison: Comparison,
+        constraint_system: ConstraintSystemRef<F>,
+    ) -> Result<Boolean<F>>
+    where
+        Self: std::marker::Sized,
+    {
+        helpers::compare_ord(self, gadget_to_compare, comparison, constraint_system)
     }
 }
 


### PR DESCRIPTION
All the implementations for arithmetic and comparison operations were moved to simpleworks. This approach allow us to use these functions in the VM without creating one helper function for each new operation.